### PR TITLE
Rebranding to kompose

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -26,7 +26,7 @@ func BeforeApp(c *cli.Context) error {
 	if c.GlobalBool("verbose") {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	logrus.Warning("Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose)")
+	// logrus.Warning("Note: This is an experimental alternate implementation of the Docker Compose CLI (https://github.com/docker/compose)")
 	return nil
 }
 

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -262,6 +262,21 @@ func KuberCommand(factory app.ProjectFactory) cli.Command {
 					},
 				},
 			},
+			{
+				Name:	"scale",
+				Usage:	"Globally scale instantiated replication controllers",
+				Action:	app.WithProject(factory, k8sApp.ProjectKuberScale),
+				Flags:	[]cli.Flag {
+					cli.IntFlag {
+						Name:	"scale",
+						Usage:	"New number of replicas",
+					},
+					cli.StringFlag {
+						Name:	"rc",
+						Usage:	"A specific replication controller to scale",
+					},
+				},
+			},
 		},
 	}
 }

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -14,11 +14,11 @@ func main() {
 	factory := &dockerApp.ProjectFactory{}
 
 	app := cli.NewApp()
-	app.Name = "libcompose-cli"
-	app.Usage = "Command line interface for libcompose."
+	app.Name = "kompose"
+	app.Usage = "Command line interface for Skippbox."
 	app.Version = version.VERSION + " (" + version.GITCOMMIT + ")"
-	app.Author = "Docker Compose Contributors"
-	app.Email = "https://github.com/docker/libcompose"
+	app.Author = "Skippbox Compose Contributors"
+	app.Email = "https://github.com/skippbox/kompose"
 	app.Before = cliApp.BeforeApp
 	app.Flags = append(command.CommonFlags(), dockerApp.DockerClientFlags()...)
 	app.Commands = []cli.Command{

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -90,7 +90,7 @@ func (s *RunSuite) TearDownTest(c *C) {
 }
 
 var _ = Suite(&RunSuite{
-	command: "../bundles/libcompose-cli_linux-amd64",
+	command: "../bundles/kompose_linux-amd64",
 })
 
 func (s *RunSuite) CreateProjectFromText(c *C, input string) string {

--- a/script/.validate
+++ b/script/.validate
@@ -4,7 +4,7 @@ if [ -z "$VALIDATE_UPSTREAM" ]; then
 	# this is kind of an expensive check, so let's not do this twice if we
 	# are running more than one validate bundlescript
 	
-	VALIDATE_REPO='https://github.com/docker/libcompose.git'
+	VALIDATE_REPO='https://github.com/skippbox/kompose.git'
 	VALIDATE_BRANCH='master'
 	
 	if [ "$TRAVIS" = 'true' -a "$TRAVIS_PULL_REQUEST" != 'false' ]; then

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -13,7 +13,7 @@ venv/bin/pip install \
     -r venv/compose/requirements.txt \
     -r venv/compose/requirements-dev.txt
 
-cp bundles/libcompose-cli_linux-amd64 venv/bin/docker-compose
+cp bundles/kompose_linux-amd64 venv/bin/docker-compose
 . venv/bin/activate
 
 docker-compose --version


### PR DESCRIPTION
Disabled the warning that appears on the command line for each invocation, and updated some of the text strings to reflect the new kompose name instead of the docker-compose label.