### PR TITLE
Kompose rc/service named deletion and Chart/Deployment generation

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -260,6 +260,10 @@ func KuberCommand(factory app.ProjectFactory) cli.Command {
 						Name: "services,s",
 						Usage: "Remove active services",
 					},
+					cli.StringFlag {
+						Name:	"name",
+						Usage:	"Name of the object to remove",
+					},
 				},
 			},
 			{

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -230,6 +230,14 @@ func KuberCommand(factory app.ProjectFactory) cli.Command {
 						Value:	"docker-compose.yml",
 						EnvVar: "COMPOSE_FILE",
 					},
+					cli.BoolFlag{
+						Name:	"deployment,d",
+						Usage:	"Generate a deployment resource file",
+					},
+					cli.BoolFlag{
+						Name:	"chart,c",
+						Usage:	"Create a chart deployment",
+					},
 				},
 			},
 			{

--- a/cli/k8s/app/commands.go
+++ b/cli/k8s/app/commands.go
@@ -106,6 +106,10 @@ func ProjectKuberDelete(p *project.Project, c *cli.Context) {
     client := client.NewOrDie(&client.Config{Host: server, Version: version})
 
     for name := range p.Configs {
+		if len(c.String("name")) > 0 && name != c.String("name") {
+			continue
+		}
+
         if c.BoolT("services") {
             err := client.Services(api.NamespaceDefault).Delete(name)
             if err != nil {

--- a/cli/k8s/app/k8sutil.go
+++ b/cli/k8s/app/k8sutil.go
@@ -1,8 +1,11 @@
 package app
 
 import (
+    "bytes"
     "io/ioutil"
+    "os"
     "strings"
+    "text/template"
     "regexp"
 
     "github.com/Sirupsen/logrus"
@@ -33,4 +36,85 @@ func getK8sServer(file string) string {
     }
 
     return server
+}
+
+/**
+ * Generate Helm Chart configuration
+ */
+func generateHelm(filename string, svcname string) error {
+    type ChartDetails struct {
+        Name string
+    }
+
+    dirName := strings.Replace(filename, ".yml", "", 1)
+    details := ChartDetails{dirName}
+    manifestDir := dirName + string(os.PathSeparator) + "manifests"
+    dir,err := os.Open(dirName)
+
+    /* Setup the initial directories/files */
+    if err == nil {
+        _ = dir.Close()
+    }
+
+    if err != nil {
+        err = os.Mkdir(dirName, 0755)
+        if err != nil {
+            return err
+        }
+
+        err = os.Mkdir(manifestDir, 0755)
+        if err != nil {
+            return err
+        }
+
+        /* Create the readme file */
+        readme := "This chart was created by Kompose\n"
+        err = ioutil.WriteFile(dirName + string(os.PathSeparator) + "README.md", []byte(readme), 0644)
+        if err != nil {
+            return err
+        }
+
+        /* Create the Chart.yaml file */
+        chart := `name: {{.Name}}
+description: A generated Helm Chart from Skippbox Kompose
+version: 0.0.1
+source:
+home:
+`
+
+        t, err := template.New("ChartTmpl").Parse(chart)
+        if err != nil {
+            logrus.Fatalf("Failed to generate Chart.yaml template: %s\n", err)
+        }
+        var chartData bytes.Buffer
+        _ = t.Execute(&chartData, details)
+
+        err = ioutil.WriteFile(dirName + string(os.PathSeparator) + "Chart.yaml", chartData.Bytes(), 0644)
+        if err != nil {
+            return err
+        }
+    }
+
+    /* Copy all yaml files into the newly created manifests directory */
+    infile, err := ioutil.ReadFile(svcname + "-rc.yaml")
+    if err != nil {
+        logrus.Infof("Error reading %s: %s\n", svcname + "-rc.yaml", err)
+        return err
+    }
+
+    err = ioutil.WriteFile(manifestDir + string(os.PathSeparator) + svcname + "-rc.yaml", infile, 0644)
+    if err != nil {
+        return err
+    }
+
+    /* The svc file is optional */
+    infile, err = ioutil.ReadFile(svcname + "-svc.yaml")
+    if err == nil {
+        err = ioutil.WriteFile(manifestDir + string(os.PathSeparator) + svcname + "-svc.yaml", infile, 0644)
+        if err != nil {
+           return err
+        }
+    }
+
+    return nil
 }


### PR DESCRIPTION
- Support for generation of Helm's Chart repo (k8s convert --chart)
- Support for per-RC deployment configuration files (k8s convert --deployment)
- Support for deletion of a per rc/service based on the name (k8s delete --name=foo)

For the Chart/Deployment configuration, use of either --chart or --deployment will result in files being created, but not posted to the kubernetes server referenced in the kuberconfig file.