### PR TITLE
Add --bundle,-dab flag for specifying dab file

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -1061,9 +1061,11 @@ func Convert(c *cli.Context) {
 	}
 
 	komposeObject := KomposeObject{}
+	file := inputFile
 
 	if len(dabFile) > 0 {
 		komposeObject = loadBundlesFile(dabFile)
+		file = dabFile
 	} else {
 		komposeObject = loadComposeFile(inputFile, c)
 	}
@@ -1079,7 +1081,7 @@ func Convert(c *cli.Context) {
 		createChart:            createChart,
 		generateYaml:           generateYaml,
 		replicas:               replicas,
-		inputFile:              inputFile,
+		inputFile:              file,
 		outFile:                outFile,
 		f:                      f,
 	}

--- a/cli/app/k8sutils.go
+++ b/cli/app/k8sutils.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
+	"path/filepath"
 	"text/template"
 
 	"github.com/Sirupsen/logrus"
@@ -37,7 +37,8 @@ func generateHelm(filename string, svcnames []string, generateYaml, createD, cre
 		Name string
 	}
 
-	dirName := strings.Replace(filename, ".yml", "", 1)
+	extension := filepath.Ext(filename)
+	dirName := filename[0 : len(filename)-len(extension)]
 	details := ChartDetails{dirName}
 	manifestDir := dirName + string(os.PathSeparator) + "templates"
 	dir, err := os.Open(dirName)

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -17,6 +17,8 @@ limitations under the License.
 package command
 
 import (
+	"fmt"
+
 	"github.com/skippbox/kompose/cli/app"
 	"github.com/urfave/cli"
 )
@@ -25,16 +27,21 @@ import (
 func ConvertCommand() cli.Command {
 	return cli.Command{
 		Name:  "convert",
-		Usage: "Convert docker-compose.yml to Kubernetes objects",
+		Usage: fmt.Sprintf("Convert %s to Kubernetes objects", app.DefaultComposeFile),
 		Action: func(c *cli.Context) {
 			app.Convert(c)
 		},
 		Flags: []cli.Flag{
 			cli.StringFlag{
 				Name:   "file,f",
-				Usage:  "Specify an alternate compose file (default: docker-compose.yml)",
-				Value:  "docker-compose.yml",
+				Usage:  fmt.Sprintf("Specify an alternate compose file (default: %s)", app.DefaultComposeFile),
+				Value:  app.DefaultComposeFile,
 				EnvVar: "COMPOSE_FILE",
+			},
+			cli.StringFlag{
+				Name:   "bundle,dab",
+				Usage:  "Specify a Distributed Application Bundle (DAB) file",
+				EnvVar: "DAB_FILE",
 			},
 			cli.StringFlag{
 				Name:   "out,o",
@@ -77,11 +84,6 @@ func ConvertCommand() cli.Command {
 			cli.BoolFlag{
 				Name:  "stdout",
 				Usage: "Print Kubernetes objects to stdout",
-			},
-			// FIXME: this flag should be used together with --file/-f in order to specify dab file.
-			cli.BoolFlag{
-				Name:  "from-bundles",
-				Usage: "Getting input from docker DAB file",
 			},
 		},
 	}


### PR DESCRIPTION
Now we can specify a dab file with `--bundle` or `-dab`:

```console
$ kompose convert --bundle=docker-compose-bundle.dsb 
file "redis-svc.json" created
file "web-svc.json" created
file "redis-deployment.json" created
file "web-deployment.json" created
```

`--bundle` can't be used with `--file`: 
```console
$ kompose convert --bundle=docker-compose-bundle.dsb --file=docker-gitlab.yml
FATA[0000] Error: compose file and dab file cannot be specified at the same time
```

Fixes #53 
