### PR TITLE
Warning on missing port information and no service created

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -932,10 +932,16 @@ func komposeConvert(komposeObject KomposeObject, opt convertOptions) {
 			logrus.Fatalf(err.Error())
 		}
 
-		// convert datasvc to json / yaml
-		datasvc, err := transformer(sc, opt.generateYaml)
-		if err != nil {
-			logrus.Fatalf(err.Error())
+		var datasvc []byte
+		// If ports not provided in configuration we will not make service
+		if len(ports) == 0 {
+			logrus.Warningf("[%s] Service cannot be created because of missing port.", name)
+		} else {
+			// convert datasvc to json / yaml
+			datasvc, err = transformer(sc, opt.generateYaml)
+			if err != nil {
+				logrus.Fatalf(err.Error())
+			}
 		}
 
 		// convert OpenShift DeploymentConfig to json / yaml


### PR DESCRIPTION
Now when user will not provide any port information a warning will be shown and also service will not be created.

Fixes #58