### PR TITLE
Enable warnings in stdout

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -747,9 +747,7 @@ func loadBundlesFile(file string, opt convertOptions) KomposeObject {
 	}
 
 	for name, service := range bundle.Services {
-		if !opt.toStdout {
-			checkUnsupportedKey(service)
-		}
+		checkUnsupportedKey(service)
 		serviceConfig := ServiceConfig{}
 		serviceConfig.Command = service.Command
 		serviceConfig.Args = service.Args
@@ -823,9 +821,7 @@ func loadComposeFile(file string, opt convertOptions) KomposeObject {
 	composeServiceNames := composeObject.ServiceConfigs.Keys()
 	for _, name := range composeServiceNames {
 		if composeServiceConfig, ok := composeObject.ServiceConfigs.Get(name); ok {
-			if !opt.toStdout {
-				checkUnsupportedKey(composeServiceConfig)
-			}
+			checkUnsupportedKey(composeServiceConfig)
 			serviceConfig := ServiceConfig{}
 			serviceConfig.Image = composeServiceConfig.Image
 			serviceConfig.ContainerName = composeServiceConfig.ContainerName
@@ -989,7 +985,7 @@ func komposeConvert(komposeObject KomposeObject, opt convertOptions) {
 
 		var datasvc []byte
 		// If ports not provided in configuration we will not make service
-		if len(ports) == 0 && !opt.toStdout {
+		if len(ports) == 0 {
 			logrus.Warningf("[%s] Service cannot be created because of missing port.", name)
 		} else if len(ports) != 0 {
 			// convert datasvc to json / yaml


### PR DESCRIPTION
Ref #71

With this change, you see warnings even when `--stdout` is specified:
```console
$ kompose convert -f docker-voting.yml -y --stdout | kubectl create -f - 
time="2016-08-03T11:39:37-07:00" level=warning msg="Unsupported key build - ignoring" 
time="2016-08-03T11:39:37-07:00" level=warning msg="Unsupported key networks - ignoring" 
time="2016-08-03T11:39:37-07:00" level=warning msg="[worker] Service cannot be created because of missing port." 
time="2016-08-03T11:39:37-07:00" level=warning msg="[db] Service cannot be created because of missing port." 
service "redis" created
service "result" created
service "vote" created
deployment "db" created
deployment "redis" created
Error from server: error when creating "STDIN": Deployment.extensions "vote" is invalid: spec.template.spec.containers[0].image: Required value
Error from server: error when creating "STDIN": Deployment.extensions "worker" is invalid: spec.template.spec.containers[0].image: Required value
Error from server: error when creating "STDIN": Deployment.extensions "result" is invalid: spec.template.spec.containers[0].image: Required value