### PR TITLE
Clean up kompose help, remove support for unimplemented commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/skippbox/kompose.svg?branch=master)](https://travis-ci.org/skippbox/kompose) [![Join us on Slack](https://s3.eu-central-1.amazonaws.com/ngtuna/join-us-on-slack.png)](https://skippbox.herokuapp.com)
 
-`kompose` is a tool to help users familiar with `docker-compose` move to [Kubernetes](http://kubernetes.io). It takes a Docker Compose file and translates it into Kubernetes objects, it can then submit those objects to a Kubernetes endpoint with the `kompose up` command.
+`kompose` is a tool to help users familiar with `docker-compose` move to [Kubernetes](http://kubernetes.io). It takes a Docker Compose file and translates it into Kubernetes objects.
 
 `kompose` is a convenience tool to go from local Docker development to managing your application with Kubernetes. We don't assume that the transformation from docker compose format to Kubernetes API objects will be perfect, but it helps tremendously to start _Kubernetizing_ your application.
 

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -27,7 +27,7 @@ import (
 func ConvertCommand() cli.Command {
 	return cli.Command{
 		Name:  "convert",
-		Usage: fmt.Sprintf("Convert %s to Kubernetes objects", app.DefaultComposeFile),
+		Usage: fmt.Sprintf("Convert Docker Compose file (e.g. %s) to Kubernetes objects", app.DefaultComposeFile),
 		Action: func(c *cli.Context) {
 			app.Convert(c)
 		},
@@ -165,15 +165,5 @@ func ScaleCommand() cli.Command {
 
 // CommonFlags defines the flags that are in common for all subcommands.
 func CommonFlags() []cli.Flag {
-	return []cli.Flag{
-		cli.BoolFlag{
-			Name: "verbose,debug",
-		},
-		cli.StringFlag{
-			Name:   "file,f",
-			Usage:  "Specify an alternate compose file (default: docker-compose.yml)",
-			Value:  "docker-compose.yml",
-			EnvVar: "COMPOSE_FILE",
-		},
-	}
+	return []cli.Flag{}
 }

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -28,19 +28,20 @@ import (
 func main() {
 	app := cli.NewApp()
 	app.Name = "kompose"
-	app.Usage = "Command line interface for Skippbox."
+	app.Usage = "A tool helping Docker Compose users move to Kubernetes."
 	app.Version = version.VERSION + " (" + version.GITCOMMIT + ")"
-	app.Author = "Skippbox Compose Contributors"
+	app.Author = "Skippbox Kompose Contributors"
 	app.Email = "https://github.com/skippbox/kompose"
 	app.EnableBashCompletion = true
 	app.Before = cliApp.BeforeApp
 	app.Flags = append(command.CommonFlags())
 	app.Commands = []cli.Command{
 		command.ConvertCommand(),
-		command.UpCommand(),
-		command.PsCommand(),
-		command.DeleteCommand(),
-		command.ScaleCommand(),
+		// TODO: enable these commands and update docs once we fix them
+		//command.UpCommand(),
+		//command.PsCommand(),
+		//command.DeleteCommand(),
+		//command.ScaleCommand(),
 	}
 
 	app.Run(os.Args)


### PR DESCRIPTION
Fixes #76 

1. Updated `kompose`: command name becomes "kompose - A tool helping Docker Compose users move to Kubernetes.".  Removed support for `up`, `scale`, `delete`, `ps` (we'll add them back once they're implemented).  Removed global options not in-use (`--debug`, `-f`)
2. Updated `kompose convert help`: name becomes "kompose convert - Convert Docker Compose file (e.g. docker-compose.yml) to Kubernetes objects"
3. Removed `kompose up` from README