### PR TITLE
Run tests on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
+# we need trusty because test-cmd depends on jq  version >= 1.5
+dist : trusty
 sudo: required
+
 
 language: go
 
 go:
   - 1.6
 
-branches:
-  only:
-    - master
-
 install:
-- go get github.com/mitchellh/gox
-- go get github.com/tools/godep
-- ./script/godep-restore.sh
+  - true
 
 script:
-- make binary
+  - make binary
+  # $GOPATH/bin is in $PATH
+  - mkdir $GOPATH/bin
+  - cp kompose $GOPATH/bin/
+
+  - make test-unit
+  - make test-cmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 script:
   - make binary
   # $GOPATH/bin is in $PATH
-  - mkdir $GOPATH/bin
+  - mkdir -p $GOPATH/bin
   - cp kompose $GOPATH/bin/
 
   - make test-unit

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,9 @@ all:
 
 binary:
 	CGO_ENABLED=0 ./script/make.sh binary
+
+binary-cross:
+	CGO_ENABLED=0 ./script/make.sh binary-cross
+
+clean:
+	./script/make.sh clean

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ binary-cross:
 
 clean:
 	./script/make.sh clean
+
+test-unit:
+	./script/make.sh test-unit
+
+test-cmd:
+	./script/make.sh test-cmd

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ file "redis-deployment.json" created
 The default `kompose` transformation will generate Kubernetes [Deployments](http://kubernetes.io/docs/user-guide/deployments/) and [Services](http://kubernetes.io/docs/user-guide/services/), in json format. You have alternative option to generate yaml with `-y`. Also, you can alternatively generate [Replication Controllers](http://kubernetes.io/docs/user-guide/replication-controller/) objects, [Deamon Sets](http://kubernetes.io/docs/admin/daemons/), or [Helm](https://github.com/helm/helm) charts.
 
 ```console
-$ kompose convert 
+$ kompose convert
 file "redis-svc.json" created
 file "web-svc.json" created
 file "redis-deployment.json" created
@@ -180,7 +180,7 @@ You need `-tags experimental` because the current `bundlefile` package of docker
 - You need `make`
 
 ```console
-$ make binary
+$ make binary-cross
 ```
 
 ## Contributing and Issues

--- a/script/.build
+++ b/script/.build
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+GITCOMMIT=$(git rev-parse --short HEAD)
+
+BUILD_FLAGS=(-tags experimental -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}")

--- a/script/binary
+++ b/script/binary
@@ -10,3 +10,9 @@ go build \
     -o kompose \
     -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}" \
     ./cli/main
+
+if [ $? -eq 0 ]; then
+  echo "Build successful. Program saved as ${OUT_FILE}"
+else
+  echo "Build failed."
+fi

--- a/script/binary
+++ b/script/binary
@@ -1,26 +1,12 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]; then
-    OS_PLATFORM_ARG=(-os="darwin linux windows")
-else
-    OS_PLATFORM_ARG=($1)
-fi
+# Get rid of existing binary
+rm -f kompose
 
-if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64")
-else
-    OS_ARCH_ARG=($2)
-fi
-
-GITCOMMIT=$(git rev-parse --short HEAD)
-
-# Get rid of existing binaries
-rm -f kompose*
-
-# Build binaries
-gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
-    -output="bundles/kompose_{{.OS}}-{{.Arch}}/kompose" \
+# Build binary
+go build \
     -tags experimental \
+    -o kompose \
     -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}" \
     ./cli/main

--- a/script/binary
+++ b/script/binary
@@ -1,14 +1,17 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$BASH_SOURCE")/.build"
+
+OUT_FILE="./kompose"
+
 # Get rid of existing binary
-rm -f kompose
+rm -f $OUT_FILE
 
 # Build binary
 go build \
-    -tags experimental \
-    -o kompose \
-    -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}" \
+    "${BUILD_FLAGS[@]}" \
+    -o $OUT_FILE \
     ./cli/main
 
 if [ $? -eq 0 ]; then

--- a/script/binary-cross
+++ b/script/binary-cross
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$BASH_SOURCE")/.build"
+
 if [ -z "$1" ]; then
     OS_PLATFORM_ARG=(-os="darwin linux windows")
 else
@@ -21,6 +23,5 @@ rm -f kompose*
 # Build binaries
 gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
     -output="bundles/kompose_{{.OS}}-{{.Arch}}/kompose" \
-    -tags experimental \
-    -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}" \
+    "${BUILD_FLAGS[@]}" \
     ./cli/main

--- a/script/binary-cross
+++ b/script/binary-cross
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+    OS_PLATFORM_ARG=(-os="darwin linux windows")
+else
+    OS_PLATFORM_ARG=($1)
+fi
+
+if [ -z "$2" ]; then
+    OS_ARCH_ARG=(-arch="386 amd64")
+else
+    OS_ARCH_ARG=($2)
+fi
+
+GITCOMMIT=$(git rev-parse --short HEAD)
+
+# Get rid of existing binaries
+rm -f kompose*
+
+# Build binaries
+gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
+    -output="bundles/kompose_{{.OS}}-{{.Arch}}/kompose" \
+    -tags experimental \
+    -ldflags="-w -X github.com/skippbox/kompose/version.GITCOMMIT=${GITCOMMIT}" \
+    ./cli/main

--- a/script/test-cmd
+++ b/script/test-cmd
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./script/test/cmd/tests.sh

--- a/script/test-unit
+++ b/script/test-unit
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+find_dirs() {
+  (
+    find . -not \( \
+        \( \
+          -path './vendor/*' \
+        \) -prune \
+      \) -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./||' | sort -u
+  )
+}
+
+TEST_FLAGS="-tags experimental -cover -coverprofile=cover.out"
+
+if [ -z "$TEST_DIRS" ]; then
+  TEST_DIRS=$(find_dirs '*_test.go')
+fi
+
+TESTS_FAILED=()
+
+set +e
+for dir in $TEST_DIRS; do
+  go test ${TEST_FLAGS} "./${dir}"
+done

--- a/script/test-unit
+++ b/script/test-unit
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source "$(dirname "$BASH_SOURCE")/.build"
+
 find_dirs() {
   (
     find . -not \( \
@@ -11,7 +13,7 @@ find_dirs() {
   )
 }
 
-TEST_FLAGS="-tags experimental -cover -coverprofile=cover.out"
+TEST_FLAGS=("${BUILD_FLAGS[@]}" -cover -coverprofile=cover.out)
 
 if [ -z "$TEST_DIRS" ]; then
   TEST_DIRS=$(find_dirs '*_test.go')
@@ -19,7 +21,6 @@ fi
 
 TESTS_FAILED=()
 
-set +e
 for dir in $TEST_DIRS; do
-  go test ${TEST_FLAGS} "./${dir}"
+  go test "${TEST_FLAGS[@]}" "./${dir}"
 done


### PR DESCRIPTION
related to #34 

-  run commandline tests and unit test on travis-ci (`make test-unit` and `make test-cmd`)
- `make binary` builds only binary for current arch platform where script is running (no cross compiling)
- added `make binary-cross` same as former `make binary` (cross compile for mac/linux/win 386/amd65)

command line test is failing because of #88 and #92 