### PR TITLE
Build statically linked binaries in makefile; remove make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,3 @@ all:
 
 binary:
 	CGO_ENABLED=0 ./script/make.sh binary
-
-clean:
-	./script/make.sh clean
-

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ BIND_DIR := bundles
 default: binary
 
 all:
-	./script/make.sh
+	CGO_ENABLED=0 ./script/make.sh
 
 binary:
-	./script/make.sh binary
+	CGO_ENABLED=0 ./script/make.sh binary
 
 clean:
 	./script/make.sh clean


### PR DESCRIPTION
Fixes #98

Now `make binary`, `make all` or `make default` gives me statically linked binaries:

```console
$ ldd bundles/kompose_linux-amd64/kompose 
	not a dynamic executable
$ file bundles/kompose_linux-amd64/kompose 
bundles/kompose_linux-amd64/kompose: ELF 64-bit LSB  executable, x86-64, version 1 (SYSV), statically linked, not stripped
```

Also removed `make clean` since the clean script doesn't exist.