### PR TITLE
Reuse creation of controller object code

### DIFF
--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -67,17 +67,8 @@ func (k *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 	var allobjects []runtime.Object
 
 	for name, service := range komposeObject.ServiceConfigs {
-		var objects []runtime.Object
+		objects := kubernetes.CreateKubernetesObjects(name, service, opt)
 
-		if opt.CreateD {
-			objects = append(objects, kubernetes.InitD(name, service, opt.Replicas))
-		}
-		if opt.CreateDS {
-			objects = append(objects, kubernetes.InitDS(name, service))
-		}
-		if opt.CreateRC {
-			objects = append(objects, kubernetes.InitRC(name, service, opt.Replicas))
-		}
 		if opt.CreateDeploymentConfig {
 			objects = append(objects, initDeploymentConfig(name, service, opt.Replicas)) // OpenShift DeploymentConfigs
 		}


### PR DESCRIPTION
The repated controller creation code has been removed. And aggregated it into a single function, that Kubernetes and OpenShift providers' Transform code can call.