### PR TITLE
docker-compose - Entrypoint support

### DIFF
--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -145,7 +145,6 @@ type ServiceConfig struct {
 	CPUQuota      int64
 	CapAdd        []string
 	CapDrop       []string
-	Entrypoint    []string
 	Expose        []string
 	Privileged    bool
 	Restart       string

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -35,7 +35,6 @@ var unsupportedKey = map[string]int{
 	"DNS":           0,
 	"DNSSearch":     0,
 	"DomainName":    0,
-	"Entrypoint":    0,
 	"EnvFile":       0,
 	"Expose":        0,
 	"Extends":       0,

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -151,8 +151,8 @@ func (c *Compose) LoadFile(file string) kobject.KomposeObject {
 			serviceConfig := kobject.ServiceConfig{}
 			serviceConfig.Image = composeServiceConfig.Image
 			serviceConfig.ContainerName = composeServiceConfig.ContainerName
-			serviceConfig.Entrypoint = composeServiceConfig.Entrypoint
-			serviceConfig.Command = composeServiceConfig.Command
+			serviceConfig.Command = composeServiceConfig.Entrypoint
+			serviceConfig.Args = composeServiceConfig.Command
 
 			// load environment variables
 			envs := loadEnvVars(composeServiceConfig.Environment.ToMap())

--- a/pkg/loader/compose/compose.go
+++ b/pkg/loader/compose/compose.go
@@ -119,6 +119,7 @@ func (c *Compose) LoadFile(file string) kobject.KomposeObject {
 
 	// load compose file into composeObject
 	composeObject := project.NewProject(&context.Context, nil, nil)
+
 	err := composeObject.Parse()
 	if err != nil {
 		logrus.Fatalf("Failed to load compose file: %v", err)
@@ -150,6 +151,8 @@ func (c *Compose) LoadFile(file string) kobject.KomposeObject {
 			serviceConfig := kobject.ServiceConfig{}
 			serviceConfig.Image = composeServiceConfig.Image
 			serviceConfig.ContainerName = composeServiceConfig.ContainerName
+			serviceConfig.Entrypoint = composeServiceConfig.Entrypoint
+			serviceConfig.Command = composeServiceConfig.Command
 
 			// load environment variables
 			envs := loadEnvVars(composeServiceConfig.Environment.ToMap())

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -258,8 +258,8 @@ func UpdateKubernetesObjects(name string, service kobject.ServiceConfig, objects
 			template.Spec.Containers[0].Name = service.ContainerName
 		}
 		template.Spec.Containers[0].Env = envs
-		template.Spec.Containers[0].Command = service.Entrypoint
-		template.Spec.Containers[0].Args = service.Command
+		template.Spec.Containers[0].Command = service.Command
+		template.Spec.Containers[0].Args = service.Args
 		template.Spec.Containers[0].WorkingDir = service.WorkingDir
 		template.Spec.Containers[0].VolumeMounts = volumesMount
 		template.Spec.Volumes = volumes

--- a/pkg/transformer/kubernetes/k8sutils.go
+++ b/pkg/transformer/kubernetes/k8sutils.go
@@ -243,9 +243,6 @@ func UpdateKubernetesObjects(name string, service kobject.ServiceConfig, objects
 	// Configure the environment variables.
 	envs := ConfigEnvs(name, service)
 
-	// Configure the container command.
-	cmds := transformer.ConfigCommands(service)
-
 	// Configure the container volumes.
 	volumesMount, volumes := ConfigVolumes(service)
 
@@ -261,8 +258,8 @@ func UpdateKubernetesObjects(name string, service kobject.ServiceConfig, objects
 			template.Spec.Containers[0].Name = service.ContainerName
 		}
 		template.Spec.Containers[0].Env = envs
-		template.Spec.Containers[0].Command = cmds
-		template.Spec.Containers[0].Args = service.Args
+		template.Spec.Containers[0].Command = service.Entrypoint
+		template.Spec.Containers[0].Args = service.Command
 		template.Spec.Containers[0].WorkingDir = service.WorkingDir
 		template.Spec.Containers[0].VolumeMounts = volumesMount
 		template.Spec.Volumes = volumes

--- a/pkg/transformer/kubernetes/kubernetes_test.go
+++ b/pkg/transformer/kubernetes/kubernetes_test.go
@@ -42,13 +42,12 @@ func newServiceConfig() kobject.ServiceConfig {
 		Network:       []string{"network1", "network2"}, // not supported
 		Labels:        nil,
 		Annotations:   map[string]string{"abc": "def"},
-		CPUSet:        "cpu_set",              // not supported
-		CPUShares:     1,                      // not supported
-		CPUQuota:      1,                      // not supported
-		CapAdd:        []string{"cap_add"},    // not supported
-		CapDrop:       []string{"cap_drop"},   // not supported
-		Entrypoint:    []string{"entrypoint"}, // not supported
-		Expose:        []string{"expose"},     // not supported
+		CPUSet:        "cpu_set",            // not supported
+		CPUShares:     1,                    // not supported
+		CPUQuota:      1,                    // not supported
+		CapAdd:        []string{"cap_add"},  // not supported
+		CapDrop:       []string{"cap_drop"}, // not supported
+		Expose:        []string{"expose"},   // not supported
 		Privileged:    true,
 		Restart:       "always",
 		User:          "user", // not supported

--- a/pkg/transformer/utils.go
+++ b/pkg/transformer/utils.go
@@ -41,16 +41,6 @@ func CreateOutFile(out string) *os.File {
 	return f
 }
 
-// Configure the container commands
-func ConfigCommands(service kobject.ServiceConfig) []string {
-	var cmds []string
-	for _, cmd := range service.Command {
-		cmds = append(cmds, cmd)
-	}
-
-	return cmds
-}
-
 // parseVolume parse a given volume, which might be [name:][host:]container[:access_mode]
 func ParseVolume(volume string) (name, host, container, mode string, err error) {
 	separator := ":"

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -34,5 +34,14 @@ convert::expect_success_and_warning "kompose convert --stdout -f $KOMPOSE_ROOT/s
 # openshift test
 convert::expect_success_and_warning "kompose convert --stdout --dc -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-os.json" "Unsupported key build - ignoring"
 
+
+######
+# Tests related to docker-compose file in /script/test/fixtures/entrypoint-command
+# kubernetes test
+convert::expect_success_and_warning "kompose convert --stdout -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-k8s.json" "Service cannot be created because of missing port."
+# openshift test
+convert::expect_success_and_warning "kompose convert --stdout --dc -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-os.json" "Service cannot be created because of missing port."
+
+
 exit $EXIT_STATUS
 

--- a/script/test/fixtures/entrypoint-command/docker-compose.yml
+++ b/script/test/fixtures/entrypoint-command/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+services:
+  base:
+    image: busybox
+    entrypoint: echo
+    command: foo

--- a/script/test/fixtures/entrypoint-command/output-k8s.json
+++ b/script/test/fixtures/entrypoint-command/output-k8s.json
@@ -1,0 +1,44 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "Deployment",
+      "apiVersion": "extensions/v1beta1",
+      "metadata": {
+        "name": "base",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "base"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "base",
+                "image": "busybox",
+                "command": [
+                  "echo"
+                ],
+                "args": [
+                  "foo"
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        },
+        "strategy": {}
+      },
+      "status": {}
+    }
+  ]
+}

--- a/script/test/fixtures/entrypoint-command/output-os.json
+++ b/script/test/fixtures/entrypoint-command/output-os.json
@@ -1,0 +1,54 @@
+{
+  "kind": "List",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "base",
+        "creationTimestamp": null,
+        "labels": {
+          "service": "base"
+        }
+      },
+      "spec": {
+        "strategy": {
+          "resources": {}
+        },
+        "triggers": null,
+        "replicas": 1,
+        "test": false,
+        "selector": {
+          "service": "base"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "service": "base"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "base",
+                "image": "busybox",
+                "command": [
+                  "echo"
+                ],
+                "args": [
+                  "foo"
+                ],
+                "resources": {}
+              }
+            ],
+            "restartPolicy": "Always"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}


### PR DESCRIPTION
We had Command and Args together with Entrypoint in Kompose object.
This doesn't make much sense, as Entrypoint and Command are same thing.
I've removed Entrypoint from Kompose object in favor of Command to keep
same naming convensions as in Kubernetes.

Entrypoint from docker-compose.yml is now saved to Command and Command
is saved to Args (http://kubernetes.io/docs/user-guide/containers/).

docker-compose.yml | Kompose object
---------------------------|----------------------
    Entrypoint              |    Command
    Command             |     Args