### PR TITLE
New guestbook example

### DIFF
--- a/examples/docker-guestbook.yml
+++ b/examples/docker-guestbook.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+  redis-master:
+    image: gcr.io/google_containers/redis:e2e 
+    ports:
+      - "6379"
+  redis-slave:
+    image: gcr.io/google_samples/gb-redisslave:v1
+    ports:
+      - "6379"
+    environment:
+      - GET_HOSTS_FROM=dns
+  frontend:
+    image: gcr.io/google-samples/gb-frontend:v4
+    ports:
+      - "80:80"
+    environment:
+      - GET_HOSTS_FROM=dns


### PR DESCRIPTION
this adds the guestbook example.

It is really sweet, it works with docker-compose (v2) on a Docker for Mac, and straight up with `kompose up` on minikube.

