### PR TITLE
Prepare up/down for other providers

### DIFF
--- a/pkg/loader/loader.go
+++ b/pkg/loader/loader.go
@@ -16,8 +16,32 @@ limitations under the License.
 
 package loader
 
-import "github.com/skippbox/kompose/pkg/kobject"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/skippbox/kompose/pkg/kobject"
+	"github.com/skippbox/kompose/pkg/loader/bundle"
+	"github.com/skippbox/kompose/pkg/loader/compose"
+)
 
 type Loader interface {
 	LoadFile(file string) kobject.KomposeObject
+}
+
+// GetLoader returns loader for given format
+func GetLoader(format string) (Loader, error) {
+	var l Loader
+
+	switch format {
+	case "bundle":
+		l = new(bundle.Bundle)
+	case "compose":
+		l = new(compose.Compose)
+	default:
+		return nil, errors.New(fmt.Sprintf("Input file format %s is not supported", format))
+	}
+
+	return l, nil
+
 }

--- a/pkg/transformer/openshift/openshift.go
+++ b/pkg/transformer/openshift/openshift.go
@@ -17,6 +17,8 @@ limitations under the License.
 package openshift
 
 import (
+	"errors"
+
 	deployapi "github.com/openshift/origin/pkg/deploy/api"
 	"github.com/skippbox/kompose/pkg/kobject"
 	"github.com/skippbox/kompose/pkg/transformer/kubernetes"
@@ -88,4 +90,12 @@ func (k *OpenShift) Transform(komposeObject kobject.KomposeObject, opt kobject.C
 	// sort all object so Services are first
 	kubernetes.SortServicesFirst(&allobjects)
 	return allobjects
+}
+
+func (k *OpenShift) Deploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error {
+	return errors.New("Not Implemented")
+}
+
+func (k *OpenShift) Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error {
+	return errors.New("Not Implemented")
 }

--- a/pkg/transformer/transformer.go
+++ b/pkg/transformer/transformer.go
@@ -22,5 +22,10 @@ import (
 )
 
 type Transformer interface {
+	// Transform converts KomposeObject to transformer specific objects.
 	Transform(kobject.KomposeObject, kobject.ConvertOptions) []runtime.Object
+	// Deploy deploys KomposeObject to provider
+	Deploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error
+	// Undeploy deletes/undeploys KomposeObject from provider
+	Undeploy(komposeObject kobject.KomposeObject, opt kobject.ConvertOptions) error
 }


### PR DESCRIPTION
Small refactoring of Up and Down code to make space for implementing up/down with other providers (OpenShift).
It moves some provider/transfomer specific functionality (like creating client) to appropriate transformer package. It makes app.go more generic at this will make adding providers little bit easier.

related to #40