### PR TITLE
Add .gitignore for Go files + compiled Kompose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+#
+# KOMPOSE SPECIFIC
+#
+
+# Ignore compiled Kompose files
+kompose
+
+#
+# GO SPECIFIC
+#
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
Adds .gitignore for common Go-related files as well as ignoring the
binary generate via go build and/or `make binary`.