### PR TITLE
--provider global flag for kompose

### DIFF
--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"os"
 
-	cliApp "github.com/skippbox/kompose/cli/app"
 	"github.com/skippbox/kompose/cli/command"
 	"github.com/skippbox/kompose/version"
 	"github.com/urfave/cli"
@@ -33,10 +32,15 @@ func main() {
 	app.Author = "Skippbox Kompose Contributors"
 	app.Email = "https://github.com/skippbox/kompose"
 	app.EnableBashCompletion = true
-	app.Before = cliApp.BeforeApp
+	app.Before = command.BeforeApp
 	app.Flags = append(command.CommonFlags())
 	app.Commands = []cli.Command{
-		command.ConvertCommand(),
+		// NOTE: Always add this in first, because this dummy command will be removed later
+		// in  command.BeforeApp function and provider specific command will be added
+		command.ConvertCommandDummy(),
+		// command.ConvertKubernetesCommand or command.ConvertOpenShiftCommand
+		// is added depending on provider mentioned.
+
 		command.UpCommand(),
 		command.DownCommand(),
 		// TODO: enable these commands and update docs once we fix them

--- a/pkg/kobject/kobject.go
+++ b/pkg/kobject/kobject.go
@@ -125,6 +125,7 @@ type ConvertOptions struct {
 	Replicas               int
 	InputFile              string
 	OutFile                string
+	Provider               string
 }
 
 // ServiceConfig holds the basic struct of a container

--- a/script/test/cmd/tests.sh
+++ b/script/test/cmd/tests.sh
@@ -14,7 +14,7 @@ export $(cat $KOMPOSE_ROOT/script/test/fixtures/etherpad/envs)
 # kubernetes test
 convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-k8s.json" "Unsupported key depends_on - ignoring"
 # openshift test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout --dc" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-os.json" "Unsupported key depends_on - ignoring"
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/etherpad/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/etherpad/output-os.json" "Unsupported key depends_on - ignoring"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/etherpad/envs | cut -d'=' -f1)
 
 ######
@@ -24,7 +24,7 @@ export $(cat $KOMPOSE_ROOT/script/test/fixtures/gitlab/envs)
 # kubernetes test
 convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-k8s.json"
 # openshift test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout --dc" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-os.json"
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/gitlab/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/gitlab/output-os.json"
 unset $(cat $KOMPOSE_ROOT/script/test/fixtures/gitlab/envs | cut -d'=' -f1)
 
 ######
@@ -32,7 +32,7 @@ unset $(cat $KOMPOSE_ROOT/script/test/fixtures/gitlab/envs | cut -d'=' -f1)
 # kubernetes test
 convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-k8s.json" "Unsupported key build - ignoring"
 # openshift test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout --dc" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-os.json" "Unsupported key build - ignoring"
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ngnix-node-redis/output-os.json" "Unsupported key build - ignoring"
 
 
 ######
@@ -40,7 +40,7 @@ convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtur
 # kubernetes test
 convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-k8s.json" "Service cannot be created because of missing port."
 # openshift test
-convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout --dc" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-os.json" "Service cannot be created because of missing port."
+convert::expect_success_and_warning "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/entrypoint-command/output-os.json" "Service cannot be created because of missing port."
 
 
 ######
@@ -48,7 +48,7 @@ convert::expect_success_and_warning "kompose -f $KOMPOSE_ROOT/script/test/fixtur
 # kubernetes test
 convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-k8s.json"
 # openshift test
-convert::expect_success "kompose -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout --dc" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-os.json"
+convert::expect_success "kompose --provider=openshift -f $KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/docker-compose.yml convert --stdout" "$KOMPOSE_ROOT/script/test/fixtures/ports-with-proto/output-os.json"
 
 
 exit $EXIT_STATUS


### PR DESCRIPTION
Now a user can select a provider using global flag `--provider=openshift` to select openshift provider
or `--provider-kubernetes` to select kubernetes provider if nothing is provided kubernetes is the default provider.

Fixes #179