### PR TITLE
fix param order in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ file "web-svc.json" created
 file "web-deployment.json" created
 file "redis-deployment.json" created
 
-$ kompose docker-compose.yml convert
+$ kompose convert docker-compose.yml
 WARN[0000]: Unsupported key networks - ignoring
 file "redis-svc.json" created
 file "web-svc.json" created


### PR DESCRIPTION
tried the latest stable (mac os x) and I had to use ``` kompose convert docker-compose.yml```